### PR TITLE
Add various formatting solutions to template and examples

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,3 +7,4 @@ cp mpi-latex-templates*.deb /output/
 cp latex/mpi.pdf /output/
 cp examples/*.pdf /output/.
 #cp examples/*.bib /output/
+cp examples/mpi-tables.tex /output/.

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,5 @@ export TEXINPUTS=.///:..//latex//:..//graphics//:
 make
 cp mpi-latex-templates*.deb /output/
 cp latex/mpi.pdf /output/
-cp examples/mpi-far.pdf /output/
-cp examples/mpi-aebr.pdf /output/
-cp examples/mpi-plenary.pdf /output/
+cp examples/*.pdf /output/.
 #cp examples/*.bib /output/

--- a/build.sh
+++ b/build.sh
@@ -7,4 +7,4 @@ cp mpi-latex-templates*.deb /output/
 cp latex/mpi.pdf /output/
 cp examples/*.pdf /output/.
 #cp examples/*.bib /output/
-cp examples/mpi-tables.tex /output/.
+#cp examples/mpi-tables.tex /output/.

--- a/examples/mpi-aebr.tex
+++ b/examples/mpi-aebr.tex
@@ -186,9 +186,12 @@ Appendix citations
   \item Textcite: \textcite{roe_necropsy_2007}
 \end{itemize}
 
+Table contents must be in 10pt
+
 \begin{table}[h]
 \caption{Appendix table}
 \begin{center}
+\fontsize{10}{12}\selectfont
 \begin{tabular}{rr}
 One & Two \\ \addlinespace
 1 & 2
@@ -201,6 +204,7 @@ One & Two \\ \addlinespace
 \begin{table}[h]
 \caption{Table in second appendix}
 \begin{center}
+\fontsize{10}{12}\selectfont
 \begin{tabular}{rr}
 Three & Four \\ \addlinespace
 3 & 4

--- a/examples/mpi-far.tex
+++ b/examples/mpi-far.tex
@@ -123,10 +123,10 @@ $$
 
 Also test how inline maths is typeset for \(B_{MSY}\) and \(B_0\). And some example equations borrowed from the \texttt{mathspec} documentation:
 
-\begin{align}
+\begin{equation}
   f(x) &= \sum_{n = -\infty}^\infty c_{n}e^{jnx} \\
   c_{n} &= \frac{1}{2}\int_{-}^{}f(x)e^{-jnx}\,\mathrm dx
-\end{align}
+\end{equation}
 
 \lipsum[3]
 

--- a/examples/mpi-far.tex
+++ b/examples/mpi-far.tex
@@ -116,10 +116,13 @@ Some additional results are in \autoref{app:the_appendix}.
 \subsection{A first level subsection}
 \subsubsection{A second level subsection}
 
-Test out the font of  numbers in text mode (1, 2, 3, 4) and in math mode $1,\ 2,\ 3,\ 4$, and:
+Test out the font of numbers in text mode (1, 2, 3, 4) and in math mode $1,\ 2,\ 3,\ 4$, and:
 $$
 1,\ 2,\ 3,\ 4 .
 $$
+
+Also test how inline maths is typeset for \(B_{MSY}\) and \(B_0\).
+
 
 \lipsum[3]
 

--- a/examples/mpi-far.tex
+++ b/examples/mpi-far.tex
@@ -121,8 +121,12 @@ $$
 1,\ 2,\ 3,\ 4 .
 $$
 
-Also test how inline maths is typeset for \(B_{MSY}\) and \(B_0\).
+Also test how inline maths is typeset for \(B_{MSY}\) and \(B_0\). And some example equations borrowed from the \texttt{mathspec} documentation:
 
+\begin{align}
+  f(x) &= \sum_{n = -\infty}^\infty c_{n}e^{jnx} \\
+  c_{n} &= \frac{1}{2}\int_{-}^{}f(x)e^{-jnx}\,\mathrm dx
+\end{align}
 
 \lipsum[3]
 

--- a/examples/mpi-far.tex
+++ b/examples/mpi-far.tex
@@ -121,11 +121,10 @@ $$
 1,\ 2,\ 3,\ 4 .
 $$
 
-Also test how inline maths is typeset for \(B_{MSY}\) and \(B_0\). And some example equations borrowed from the \texttt{mathspec} documentation:
+Also test how inline maths is typeset for \(B_{MSY}\) and \(B_0\). And some example equations:
 
 \begin{equation}
-  f(x) &= \sum_{n = -\infty}^\infty c_{n}e^{jnx} \\
-  c_{n} &= \frac{1}{2}\int_{-}^{}f(x)e^{-jnx}\,\mathrm dx
+  p_l = \frac{ \sum_{j=1}^{k} N_{ljm} }{ \sum_{j=1}^{k} (N_{ljm} + N_{jc}) }
 \end{equation}
 
 \lipsum[3]

--- a/examples/mpi-far.tex
+++ b/examples/mpi-far.tex
@@ -192,9 +192,12 @@ Appendix citations
   \item Textcite: \textcite{roe_necropsy_2007}
 \end{itemize}
 
+Table contents must be in 10pt
+
 \begin{table}[h]
 \caption{Appendix table}
 \begin{center}
+\fontsize{10}{12}\selectfont
 \begin{tabular}{rr}
 One & Two \\ \addlinespace
 1 & 2
@@ -207,6 +210,7 @@ One & Two \\ \addlinespace
 \begin{table}[h]
 \caption{Table in second appendix}
 \begin{center}
+\fontsize{10}{12}\selectfont
 \begin{tabular}{rr}
 Three & Four \\ \addlinespace
 3 & 4

--- a/examples/mpi-plenary.tex
+++ b/examples/mpi-plenary.tex
@@ -4,7 +4,7 @@
 
 \author{The Ministry for Primary Industries}
 
-\usepackage{amsmath}
+%\usepackage{amsmath}
 \usepackage{longtable}
 \usepackage{placeins}
 \usepackage{multirow}

--- a/examples/mpi-tables.rnw
+++ b/examples/mpi-tables.rnw
@@ -125,6 +125,12 @@ print(test_tab_land)
 @
 \end{flandscape}
 
+\section{Discussion}
+
+Checking that portrait pages are set properly again
+
+\lipsum[1]
+
 % Bibliography should be printed starting on a new page.
 \clearpage
 \printbibliography

--- a/examples/mpi-tables.rnw
+++ b/examples/mpi-tables.rnw
@@ -75,7 +75,8 @@ Following the \texttt{kableExtra} documentation the \texttt{mtcars} dataset, ava
     kbl(booktabs = TRUE, linesep = "",
         format.args = list(big.mark = '\u202F'),
         align = "lrrrr",
-        caption = "Checking that a kable table is formatted according to FNZ requirements.") %>%
+        caption = "Checking that a kable table is formatted according to FNZ requirements.",
+        toprule = "", bottomrule = "") %>%
     add_header_above(c(" " = 2, "Engine" = 3),
                      line = TRUE, align = "r") %>%
     kable_styling(font_size = 10,

--- a/examples/mpi-tables.rnw
+++ b/examples/mpi-tables.rnw
@@ -129,7 +129,7 @@ print(test_tab_land)
 
 Checking that portrait pages are set properly again
 
-\lipsum[1]
+\lipsum[1:10]
 
 % Bibliography should be printed starting on a new page.
 \clearpage

--- a/examples/mpi-tables.rnw
+++ b/examples/mpi-tables.rnw
@@ -61,7 +61,7 @@ options(knitr.kable.NA = '')
 Following the \texttt{kableExtra} documentation the \texttt{mtcars} dataset, available in base R, is used for testing.
 
 
-<<current_limits, results='asis')>>=
+<<current_limits, results='asis'>>=
 
   example_df <- mtcars %>%
                   mutate(disp = disp * 10) %>%

--- a/examples/mpi-tables.rnw
+++ b/examples/mpi-tables.rnw
@@ -56,6 +56,8 @@ Following the \texttt{kableExtra} documentation the \texttt{mtcars} dataset, ava
 
 \section{Results}
 
+A normal (portrait page) table is illustrated in \autoref{tab:portrait_table}. Key features are the use of 10pt font, and the only rule being under a grouped header.
+
 <<portrait_table, echo=TRUE, results='asis'>>=
 
   example_df <- mtcars %>%
@@ -79,8 +81,9 @@ Following the \texttt{kableExtra} documentation the \texttt{mtcars} dataset, ava
   print(test_tab)
 @
 
+For wide tables, a landscape page can be used. The \texttt{kableExtra} package provides a \texttt{landscape()} function.
 
-<<landscape_table, results='asis'>>=
+<<landscape_table, echo=TRUE, results='asis'>>=
 
   example_df_long <- mtcars %>%
                   mutate(disp = disp * 10,
@@ -107,15 +110,11 @@ Following the \texttt{kableExtra} documentation the \texttt{mtcars} dataset, ava
     add_header_above(c(" " = 3, "Engine" = 5, " " = 2, "Transmission" = 2),
                      line = TRUE, align = "r") %>%
     kable_styling(font_size = 10,
-                  latex_options = "hold_position")
+                  latex_options = "hold_position") %>%
+    landscape()
 
   print(test_tab_land)
 @
-
-
-
-
-\section{Discussion}
 
 
 % Bibliography should be printed starting on a new page.

--- a/examples/mpi-tables.rnw
+++ b/examples/mpi-tables.rnw
@@ -56,7 +56,7 @@ Following the \texttt{kableExtra} documentation the \texttt{mtcars} dataset, ava
 
 \section{Results}
 
-<<portrait_table, results='asis'>>=
+<<portrait_table, echo=TRUE, results='asis'>>=
 
   example_df <- mtcars %>%
                   mutate(disp = disp * 10) %>%
@@ -116,20 +116,6 @@ Following the \texttt{kableExtra} documentation the \texttt{mtcars} dataset, ava
 
 
 \section{Discussion}
-
-\subsection{A first level subsection}
-\subsubsection{A second level subsection}
-
-Test out the font of  numbers in text mode (1, 2, 3, 4) and in math mode $1,\ 2,\ 3,\ 4$, and:
-$$
-1,\ 2,\ 3,\ 4 .
-$$
-
-\lipsum[3]
-
-
-\paragraph{A minor heading}
-\lipsum[5]
 
 
 % Bibliography should be printed starting on a new page.

--- a/examples/mpi-tables.rnw
+++ b/examples/mpi-tables.rnw
@@ -69,7 +69,7 @@ Following the \texttt{kableExtra} documentation the \texttt{mtcars} dataset, ava
                          Cylinders = cyl,
                          Displacement = disp,
                          "Horse Power" = hp) %>%
-                  rownames_to_column(var = "Model") %>%
+                  rownames_to_column(var = "Model")
 
   test_tab <- example_df %>%
     kbl(booktabs = TRUE, linesep = "",

--- a/examples/mpi-tables.rnw
+++ b/examples/mpi-tables.rnw
@@ -84,8 +84,8 @@ Following the \texttt{kableExtra} documentation the \texttt{mtcars} dataset, ava
 
   example_df_long <- mtcars %>%
                   mutate(disp = disp * 10,
-                         vs = ifelse(vs == 0, 'V-shaped', 'straight),
-                         am = ifelse(am == 0, 'automatic', 'manual)) %>%
+                         vs = ifelse(vs == 0, 'V-shaped', 'straight'),
+                         am = ifelse(am == 0, 'automatic', 'manual')) %>%
                   select("1/4 mile time" = qsec,
                          MPG = mpg,
                          Cylinders = cyl,

--- a/examples/mpi-tables.rnw
+++ b/examples/mpi-tables.rnw
@@ -75,8 +75,7 @@ Following the \texttt{kableExtra} documentation the \texttt{mtcars} dataset, ava
     kbl(booktabs = TRUE, linesep = "",
         format.args = list(big.mark = '\u202F'),
         align = "lrrrr",
-        caption = "Checking that a kable table is formatted according to FNZ requirements.",
-        toprule = "", bottomrule = "") %>%
+        caption = "Checking that a kable table is formatted according to FNZ requirements.") %>%
     add_header_above(c(" " = 2, "Engine" = 3),
                      line = TRUE, align = "r") %>%
     kable_styling(font_size = 10,

--- a/examples/mpi-tables.rnw
+++ b/examples/mpi-tables.rnw
@@ -44,16 +44,17 @@ The examples below illustrate the production of properly formatted tables.
 \section{Methods}
 
 <<init, echo=TRUE, warning=FALSE, message=FALSE>>=
+# Load required packages
 library(tidyverse)
 library(kableExtra)
 
+# Define how NAs are displayed
 options(knitr.kable.NA = '')
-
 @
 
-\section{Results}
+Following the \texttt{kableExtra} documentation the \texttt{mtcars} dataset, available in base R, is used for testing. Most data frames used in analysis will need columns to be renamed for use in tables; this is conveniently done using \texttt{tidyverse} functions and is often done as part of the table-producing code block.
 
-Following the \texttt{kableExtra} documentation the \texttt{mtcars} dataset, available in base R, is used for testing.
+\section{Results}
 
 <<portrait_table, results='asis'>>=
 
@@ -62,7 +63,7 @@ Following the \texttt{kableExtra} documentation the \texttt{mtcars} dataset, ava
                   select(MPG = mpg,
                          Cylinders = cyl,
                          Displacement = disp,
-                         "Horse Power" = hp) %>%
+                         Horsepower = hp) %>%
                   rownames_to_column(var = "Model")
 
   test_tab <- example_df %>%
@@ -76,6 +77,39 @@ Following the \texttt{kableExtra} documentation the \texttt{mtcars} dataset, ava
                   latex_options = "hold_position")
 
   print(test_tab)
+@
+
+
+<<landscape_table, results='asis'>>=
+
+  example_df_long <- mtcars %>%
+                  mutate(disp = disp * 10,
+                         vs = ifelse(vs == 0, 'V-shaped', 'straight),
+                         am = ifelse(am == 0, 'automatic', 'manual)) %>%
+                  select("1/4 mile time" = qsec,
+                         MPG = mpg,
+                         Cylinders = cyl,
+                         Carburetors = carb,
+                         Displacement = disp,
+                         Horsepower = hp
+                         Shape = vs,
+                         "Rear axle ratio" = drat,
+                         Weight = wt,
+                         Type = am,
+                         "Forward gears" = gear) %>%
+                  rownames_to_column(var = "Model")
+
+  test_tab_land <- example_df_long %>%
+    kbl(booktabs = TRUE, linesep = "",
+        format.args = list(big.mark = '\u202F'),
+        align = "lrrrr",
+        caption = "Checking that a kable table is formatted according to FNZ requirements.") %>%
+    add_header_above(c(" " = 3, "Engine" = 5, " " = 2, "Transmission" = 2),
+                     line = TRUE, align = "r") %>%
+    kable_styling(font_size = 10,
+                  latex_options = "hold_position")
+
+  print(test_tab_land)
 @
 
 

--- a/examples/mpi-tables.rnw
+++ b/examples/mpi-tables.rnw
@@ -129,7 +129,7 @@ print(test_tab_land)
 
 Checking that portrait pages are set properly again
 
-\lipsum[1:10]
+\lipsum[1-10]
 
 % Bibliography should be printed starting on a new page.
 \clearpage

--- a/examples/mpi-tables.rnw
+++ b/examples/mpi-tables.rnw
@@ -58,7 +58,34 @@ options(knitr.kable.NA = '')
 
 \section{Results}
 
-Some additional results are in \autoref{app:the_appendix}.
+Following the \texttt{kableExtra} documentation the \texttt{mtcars} dataset, available in base R, is used for testing.
+
+
+<<current_limits, results='asis')>>=
+
+  example_df <- mtcars %>%
+                  mutate(disp = disp * 10) %>%
+                  select(MPG = mpg,
+                         Cylinders = cyl,
+                         Displacement = disp,
+                         "Horse Power" = hp) %>%
+                  rownames_to_column(var = "Model") %>%
+
+  test_tab <- example_df %>%
+    kbl(booktabs = TRUE, linesep = "",
+        format.args = list(big.mark = '\u202F'),
+        align = "lrrrr",
+        caption = "Checking that a kable table is formatted according to FNZ requirements.") %>%
+    add_header_above(c(" " = 2, "Engine" = 3),
+                     line = TRUE, align = "r") %>%
+    kable_styling(font_size = 10,
+                  latex_options = "HOLD_position")
+
+  print(test_tab)
+@
+
+
+
 
 \section{Discussion}
 

--- a/examples/mpi-tables.rnw
+++ b/examples/mpi-tables.rnw
@@ -1,14 +1,5 @@
 \documentclass{mpi-far}
 
-<<init, echo=FALSE, warning=FALSE, message=FALSE>>=
-library(tidyverse)
-library(kableExtra)
-
-options(knitr.kable.NA = '')
-
-@
-
-
 \title{Table formats}{Table formatting in FARs and AEBRs}
 \subtitle{A report for testing purposes}
 
@@ -39,22 +30,26 @@ options(knitr.kable.NA = '')
 
 \summary
 \citeself
+This report illustrates the use of \texttt{kable} in \texttt{knitr} files to produce tables that meet the Fisheries New Zealand formatting requirements.
 
-\lipsum[1]
 \clearpage
-
-
 \section{Introduction}
 
-%filler text
-\lipsum[1]
+The \texttt{mpi-far.tex} and \texttt{mpi-far.tex} examples illustrate how to use the Dragonfly \texttt{MPI_latex_templates} to produce Fisheries Assessment Reports and Aquatic Environment and Biodiversity Reports, respectively. Those examples are pure \LaTeX{}; however, most reproducible reports will be generated from \texttt{knitr} files with embedded R code.
 
+Tables are conveniently produced and formatted using the \texttt{kable} function and \texttt{kableExtra} package. The \texttt{MPI_latex_templates} have been set up with many of the required \LaTeX{} packages, and configuration of table dividing lines (which are used sparingly in tables in MPI reports).
+
+The examples below illustrate the production of properly formatted tables.
 
 \section{Methods}
 
-\subsection{Details}
+<<init, echo=TRUE, warning=FALSE, message=FALSE>>=
+library(tidyverse)
+library(kableExtra)
 
-\lipsum[2]
+options(knitr.kable.NA = '')
+
+@
 
 \section{Results}
 

--- a/examples/mpi-tables.rnw
+++ b/examples/mpi-tables.rnw
@@ -35,7 +35,7 @@ This report illustrates the use of \texttt{kable} in \texttt{knitr} files to pro
 \clearpage
 \section{Introduction}
 
-The \texttt{mpi-far.tex} and \texttt{mpi-far.tex} examples illustrate how to use the Dragonfly \texttt{MPI_latex_templates} to produce Fisheries Assessment Reports and Aquatic Environment and Biodiversity Reports, respectively. Those examples are pure \LaTeX{}; however, most reproducible reports will be generated from \texttt{knitr} files with embedded R code.
+The \texttt{mpi-far.tex} and \texttt{mpi-far.tex} examples illustrate how to use the Dragonfly \texttt{mpi-latex-templates} package to produce Fisheries Assessment Reports and Aquatic Environment and Biodiversity Reports, respectively. Those examples are pure \LaTeX{}; however, most reproducible reports will be generated from \texttt{knitr} files with embedded R code.
 
 Tables are conveniently produced and formatted using the \texttt{kable} function and \texttt{kableExtra} package. The \texttt{MPI_latex_templates} have been set up with many of the required \LaTeX{} packages, and configuration of table dividing lines (which are used sparingly in tables in MPI reports).
 

--- a/examples/mpi-tables.rnw
+++ b/examples/mpi-tables.rnw
@@ -91,7 +91,7 @@ Following the \texttt{kableExtra} documentation the \texttt{mtcars} dataset, ava
                          Cylinders = cyl,
                          Carburetors = carb,
                          Displacement = disp,
-                         Horsepower = hp
+                         Horsepower = hp,
                          Shape = vs,
                          "Rear axle ratio" = drat,
                          Weight = wt,

--- a/examples/mpi-tables.rnw
+++ b/examples/mpi-tables.rnw
@@ -1,6 +1,6 @@
 \documentclass{mpi-far}
 
-\title{Table formats}{Table formatting in FARs and AEBRs}
+\title{Table formats}{Table formatting in reproducible FARs and AEBRs}
 \subtitle{A report for testing purposes}
 
 \date{2023}
@@ -60,29 +60,36 @@ A normal (portrait page) table is illustrated in \autoref{tab:portrait_table}. K
 
 <<portrait_table, echo=TRUE, results='asis'>>=
 
-  example_df <- mtcars %>%
-                  mutate(disp = disp * 10) %>%
-                  select(MPG = mpg,
-                         Cylinders = cyl,
-                         Displacement = disp,
-                         Horsepower = hp) %>%
-                  rownames_to_column(var = "Model")
+% Set up an illustrative dataframe. 
+% The displacement is scaled up to illustrate thouseands formatting.
+% The dplyr select() and rename() functions are commonly used to set
+% appropriate column names.
+example_df <- mtcars %>%
+                mutate(disp = disp * 10) %>%
+                select(MPG = mpg,
+                       Cylinders = cyl,
+                       Displacement = disp,
+                       Horsepower = hp) %>%
+                rownames_to_column(var = "Model")
 
-  test_tab <- example_df %>%
-    kbl(booktabs = TRUE, linesep = "",
-        format.args = list(big.mark = '\u202F'),
-        align = "lrrrr",
-        caption = "Checking that a kable table is formatted according to FNZ requirements.") %>%
-    add_header_above(c(" " = 2, "Engine" = 3),
-                     line = TRUE, align = "r") %>%
-    kable_styling(font_size = 10,
-                  latex_options = "hold_position")
+% The LaTeX formatting is done using functions from kableExtra
+test_tab <- example_df %>%
+  kbl(booktabs = TRUE, linesep = "",
+      format.args = list(big.mark = '\u202F'),
+      align = "lrrrr",
+      caption = "Checking that a kable table is formatted 
+                 according to FNZ requirements.") %>%
+  add_header_above(c(" " = 2, "Engine" = 3),
+                   line = TRUE, align = "r") %>%
+  kable_styling(font_size = 10,
+                latex_options = "hold_position")
 
-  print(test_tab)
+print(test_tab)
 @
 
-For wide tables, a landscape page can be used. The \texttt{kableExtra} package provides a \texttt{landscape()} function.
+For wide tables, a landscape page can be used. The \texttt{kableExtra} package provides a \texttt{landscape()} function. However, this only rotates the table; MPI require a `full-landscape' page to be used with the footer rotated too. This is implemented using the \texttt{flandscape} environment provided by the \texttt{mpi-latex-templates} package.
 
+\begin{flandscape}
 <<landscape_table, echo=TRUE, results='asis'>>=
 
   example_df_long <- mtcars %>%
@@ -110,12 +117,11 @@ For wide tables, a landscape page can be used. The \texttt{kableExtra} package p
     add_header_above(c(" " = 3, "Engine" = 5, " " = 2, "Transmission" = 2),
                      line = TRUE, align = "r") %>%
     kable_styling(font_size = 10,
-                  latex_options = "hold_position") %>%
-    landscape()
+                  latex_options = "hold_position")
 
   print(test_tab_land)
 @
-
+\end{flandscape}
 
 % Bibliography should be printed starting on a new page.
 \clearpage

--- a/examples/mpi-tables.rnw
+++ b/examples/mpi-tables.rnw
@@ -76,7 +76,6 @@ example_df <- mtcars %>%
 test_tab <- example_df %>%
   kbl(booktabs = TRUE, linesep = "",
       format.args = list(big.mark = '\u202F'),
-      align = "lrrrr",
       caption = "Checking that a kable table is formatted 
                  according to FNZ requirements.") %>%
   add_header_above(c(" " = 2, "Engine" = 3),
@@ -87,7 +86,7 @@ test_tab <- example_df %>%
 print(test_tab)
 @
 
-For wide tables, a landscape page can be used. The \texttt{kableExtra} package provides a \texttt{landscape()} function. However, this only rotates the table; MPI require a `full-landscape' page to be used with the footer rotated too. This is implemented using the \texttt{flandscape} environment provided by the \texttt{mpi-latex-templates} package.
+For wide tables, a landscape page can be used. The \texttt{kableExtra} package provides a \texttt{landscape()} function. However, this only rotates the table; MPI require a `full-landscape' page to be used with the footer rotated too. This is implemented using the \texttt{flandscape} environment provided by the \texttt{mpi-latex-templates} package, and illustrated for \autoref{tab:landscape_table}.
 
 \begin{flandscape}
 <<landscape_table, echo=TRUE, results='asis'>>=
@@ -116,7 +115,6 @@ example_df_long <- mtcars %>%
 test_tab_land <- example_df_long %>%
   kbl(booktabs = TRUE, linesep = "",
       format.args = list(big.mark = '\u202F'),
-      align = "lrrrr",
       caption = "Checking that a landscape table is formatted according to FNZ requirements.") %>%
   add_header_above(c(" " = 3, "Engine" = 5, " " = 2, "Transmission" = 2),
                    line = TRUE, align = "r") %>%

--- a/examples/mpi-tables.rnw
+++ b/examples/mpi-tables.rnw
@@ -37,7 +37,7 @@ This report illustrates the use of \texttt{kable} in \texttt{knitr} files to pro
 
 The \texttt{mpi-far.tex} and \texttt{mpi-far.tex} examples illustrate how to use the Dragonfly \texttt{mpi-latex-templates} package to produce Fisheries Assessment Reports and Aquatic Environment and Biodiversity Reports, respectively. Those examples are pure \LaTeX{}; however, most reproducible reports will be generated from \texttt{knitr} files with embedded R code.
 
-Tables are conveniently produced and formatted using the \texttt{kable} function and \texttt{kableExtra} package. The \texttt{MPI_latex_templates} have been set up with many of the required \LaTeX{} packages, and configuration of table dividing lines (which are used sparingly in tables in MPI reports).
+Tables are conveniently produced and formatted using the \texttt{kable} function and \texttt{kableExtra} package. The \texttt{mpi-latex-templates} have been set up with many of the required \LaTeX{} packages, and configuration of table dividing lines (which are used sparingly in tables in MPI reports).
 
 The examples below illustrate the production of properly formatted tables.
 
@@ -55,8 +55,7 @@ options(knitr.kable.NA = '')
 
 Following the \texttt{kableExtra} documentation the \texttt{mtcars} dataset, available in base R, is used for testing.
 
-
-<<current_limits, results='asis'>>=
+<<portrait_table, results='asis'>>=
 
   example_df <- mtcars %>%
                   mutate(disp = disp * 10) %>%

--- a/examples/mpi-tables.rnw
+++ b/examples/mpi-tables.rnw
@@ -79,7 +79,7 @@ Following the \texttt{kableExtra} documentation the \texttt{mtcars} dataset, ava
     add_header_above(c(" " = 2, "Engine" = 3),
                      line = TRUE, align = "r") %>%
     kable_styling(font_size = 10,
-                  latex_options = "HOLD_position")
+                  latex_options = "hold_position")
 
   print(test_tab)
 @

--- a/examples/mpi-tables.rnw
+++ b/examples/mpi-tables.rnw
@@ -60,10 +60,10 @@ A normal (portrait page) table is illustrated in \autoref{tab:portrait_table}. K
 
 <<portrait_table, echo=TRUE, results='asis'>>=
 
-% Set up an illustrative dataframe. 
-% The displacement is scaled up to illustrate thouseands formatting.
-% The dplyr select() and rename() functions are commonly used to set
-% appropriate column names.
+# Set up an illustrative dataframe. 
+# The displacement is scaled up to illustrate thouseands formatting.
+# The dplyr select() and rename() functions are commonly used to set
+# appropriate column names.
 example_df <- mtcars %>%
                 mutate(disp = disp * 10) %>%
                 select(MPG = mpg,
@@ -72,7 +72,7 @@ example_df <- mtcars %>%
                        Horsepower = hp) %>%
                 rownames_to_column(var = "Model")
 
-% The LaTeX formatting is done using functions from kableExtra
+# The LaTeX formatting is done using functions from kableExtra
 test_tab <- example_df %>%
   kbl(booktabs = TRUE, linesep = "",
       format.args = list(big.mark = '\u202F'),
@@ -92,34 +92,38 @@ For wide tables, a landscape page can be used. The \texttt{kableExtra} package p
 \begin{flandscape}
 <<landscape_table, echo=TRUE, results='asis'>>=
 
-  example_df_long <- mtcars %>%
-                  mutate(disp = disp * 10,
-                         vs = ifelse(vs == 0, 'V-shaped', 'straight'),
-                         am = ifelse(am == 0, 'automatic', 'manual')) %>%
-                  select("1/4 mile time" = qsec,
-                         MPG = mpg,
-                         Cylinders = cyl,
-                         Carburetors = carb,
-                         Displacement = disp,
-                         Horsepower = hp,
-                         Shape = vs,
-                         "Rear axle ratio" = drat,
-                         Weight = wt,
-                         Type = am,
-                         "Forward gears" = gear) %>%
-                  rownames_to_column(var = "Model")
+# Create a wider table
+example_df_long <- mtcars %>%
+                mutate(disp = disp * 10,
+                       vs = ifelse(vs == 0, 'V-shaped', 'straight'),
+                       am = ifelse(am == 0, 'automatic', 'manual')) %>%
+                select("1/4 mile time" = qsec,
+                       MPG = mpg,
+                       Cylinders = cyl,
+                       Carburetors = carb,
+                       Displacement = disp,
+                       Horsepower = hp,
+                       Shape = vs,
+                       "Rear axle ratio" = drat,
+                       Weight = wt,
+                       Type = am,
+                       "Forward gears" = gear) %>%
+                rownames_to_column(var = "Model")
 
-  test_tab_land <- example_df_long %>%
-    kbl(booktabs = TRUE, linesep = "",
-        format.args = list(big.mark = '\u202F'),
-        align = "lrrrr",
-        caption = "Checking that a kable table is formatted according to FNZ requirements.") %>%
-    add_header_above(c(" " = 3, "Engine" = 5, " " = 2, "Transmission" = 2),
-                     line = TRUE, align = "r") %>%
-    kable_styling(font_size = 10,
-                  latex_options = "hold_position")
+# Use kable as normal for printing the table.
+# The trick is that this code block is contained in a full-landscape environment
+# \begin{flandscape} ... \end{flandscape}
+test_tab_land <- example_df_long %>%
+  kbl(booktabs = TRUE, linesep = "",
+      format.args = list(big.mark = '\u202F'),
+      align = "lrrrr",
+      caption = "Checking that a landscape table is formatted according to FNZ requirements.") %>%
+  add_header_above(c(" " = 3, "Engine" = 5, " " = 2, "Transmission" = 2),
+                   line = TRUE, align = "r") %>%
+  kable_styling(font_size = 10,
+                latex_options = "hold_position")
 
-  print(test_tab_land)
+print(test_tab_land)
 @
 \end{flandscape}
 

--- a/kahawai.yaml
+++ b/kahawai.yaml
@@ -1,1 +1,1 @@
-docker: ubuntu/texlive-r
+docker: ubuntu/texlive-r-jammy

--- a/kahawai.yaml
+++ b/kahawai.yaml
@@ -1,1 +1,1 @@
-docker: ubuntu/texlive-r-jammy
+docker: ubuntu/gorbachev-base-jammy

--- a/kahawai.yaml
+++ b/kahawai.yaml
@@ -1,1 +1,2 @@
 docker: ubuntu/gorbachev-base-jammy
+allows: [DOCKER]

--- a/kahawai.yaml
+++ b/kahawai.yaml
@@ -1,0 +1,1 @@
+docker: ubuntu/texlive-r

--- a/latex/mpi.dtx
+++ b/latex/mpi.dtx
@@ -155,20 +155,12 @@
 %
 %    \begin{macrocode}
 %<*mpi-aebr|mpi-far|mpi-plenary>
-\RequirePackage{fontspec}
-\setmainfont[Mapping=tex-text,
-    ItalicFont     = {Times New Roman Italic},
-    BoldFont       = {Times New Roman Bold},
-    BoldItalicFont = {Times New Roman Bold Italic}]{Times New Roman}
+\RequirePackage[math]{mathspec}
+\setallmainfonts{Times New Roman}
 \setsansfont[Mapping=tex-text,
   ItalicFont = {Arial Italic},
   BoldFont = {Arial Bold},
   BoldItalicFont = {Arial Bold Italic}]{Arial}
-\setmathrm[Mapping=tex-text,
-    Numbers=Monospaced,
-    ItalicFont     = {Times New Roman Italic},
-    BoldFont       = {Times New Roman Bold},
-    BoldItalicFont = {Times New Roman Bold Italic}]{Times New Roman}
 \setmathsf[Mapping=tex-text,
     Numbers=Monospaced,
     ItalicFont     = {Times New Roman Italic},

--- a/latex/mpi.dtx
+++ b/latex/mpi.dtx
@@ -806,10 +806,10 @@ Please cite this report as:
      }%
      \fancyhfoffset{0pt}% recalculate head and foot width for fancyhdr
     }
-    {\clearpage
-     \KOMAoptions{paper=portrait,DIV=current}%switch to portrait
+    {\KOMAoptions{paper=portrait,DIV=current}%switch to portrait
      \loadgeometry{defaultgeo}
      \fancyhfoffset{0pt}% <- recalculate head and foot width for fancyhdr
+     \clearpage
     }
 %</mpi-aebr|mpi-far|mpi-plenary>
 %    \end{macrocode}

--- a/latex/mpi.dtx
+++ b/latex/mpi.dtx
@@ -73,7 +73,7 @@
 % \maketitle
 %
 % \begin{abstract}
-%  This is a set of classes that are used to format \LaTeX documents according the
+%  This is a set of classes that are used to format \LaTeX{} documents according the
 %  Ministry for Primary Industries formatting requirements. There are three document
 %  classes provided: ``mpi-aebr'', for formatting Aquatic Environment and Biodiversity
 %  Reports, ``mpi-far'', for formatting Fisheries Assessment Reports and ``mpi-plenary``
@@ -129,6 +129,7 @@
 % \begin{itemize}
 % \item Aquatic Environment and Biodiversity Report
 % \item Fisheries Assessment Report
+% \item Fisheries Assessment Plenary
 % \end{itemize}
 %
 % The basic structure is the same as the base latex article class
@@ -155,8 +156,22 @@
 %
 %    \begin{macrocode}
 %<*mpi-aebr|mpi-far|mpi-plenary>
-\RequirePackage[math]{mathspec}
+\RequirePackage{mathspec}
 \setallmainfonts{Times New Roman}
+\setsansfont[Mapping=tex-text,
+  ItalicFont = {Arial Italic},
+  BoldFont = {Arial Bold},
+  BoldItalicFont = {Arial Bold Italic}]{Arial}
+\setmathsf[Mapping=tex-text,
+    Numbers=Monospaced,
+    ItalicFont     = {Times New Roman Italic},
+    BoldFont       = {Times New Roman Bold},
+    BoldItalicFont = {Times New Roman Bold Italic}]{Times New Roman}
+\setmathtt[Mapping=tex-text,
+    Numbers=Monospaced,
+    ItalicFont     = {Times New Roman Italic},
+    BoldFont       = {Times New Roman Bold},
+    BoldItalicFont = {Times New Roman Bold Italic}]{Times New Roman}
 %</mpi-aebr|mpi-far|mpi-plenary>
 %    \end{macrocode}
 %

--- a/latex/mpi.dtx
+++ b/latex/mpi.dtx
@@ -809,6 +809,7 @@ Please cite this report as:
      \KOMAoptions{paper=portrait,DIV=current}%switch to portrait
      \restoregeometry
      \pagestyle{plain}
+     \fancyhfoffset{0pt}
     }
 %</mpi-aebr|mpi-far|mpi-plenary>
 %    \end{macrocode}

--- a/latex/mpi.dtx
+++ b/latex/mpi.dtx
@@ -790,20 +790,39 @@ Please cite this report as:
 %    \end{macrocode}
 %
 %  \section{Additional Packages}
-% The hyperref package must be the last one loaded, so we load it here.
-% We also load booktabs as that is expected to be used for all tables.
+% We also various table-related packages, guided by the kableExtra requirements, 
+% and set up the booktabs rules so kable tables conform to FNZ requirements.
 %
 %    \begin{macrocode}
 %<*common>
 \RequirePackage{booktabs}
-\RequirePackage{hyperref}
+\setlength\heavyrulewidth{0ex}
+\setlength\lightrulewidth{0ex}
+\RequirePackage{longtable}
+\RequirePackage{float}
+\RequirePackage{pdflscape}
+\RequirePackage{makecell}
+\RequirePackage{xcolor}
+\RequirePackage{colortbl}
+\RequirePackage{multirow}
 %</common>
 %    \end{macrocode}
 %
-%    Hyperref should be used, but the links should not be coloured or have boxes around
-% them.
+% The SIunitx package is helpful for numbers and units.
+% FNZ specify no space between numbers and a percent symbol
 %    \begin{macrocode}
 %<*common>
+\RequirePackage{siunitx}
+\sisetup{detect-all}
+\DeclareSIUnit[quantity-product = ]\percent{\char`\%}
+%</common>
+%    \end{macrocode}
+%
+%    Hyperref must be the last package loaded. 
+%    Links should not be coloured or have boxes around them.
+%    \begin{macrocode}
+%<*common>
+\RequirePackage{hyperref}
 \hypersetup{
   colorlinks=true,
   urlcolor=black,

--- a/latex/mpi.dtx
+++ b/latex/mpi.dtx
@@ -833,7 +833,7 @@ Please cite this report as:
 \setlength\lightrulewidth{0ex}
 \RequirePackage{longtable}
 \RequirePackage{float}
-\RequirePackage{pdflscape}
+%\RequirePackage{pdflscape}
 \RequirePackage{makecell}
 \RequirePackage{xcolor}
 \RequirePackage{colortbl}

--- a/latex/mpi.dtx
+++ b/latex/mpi.dtx
@@ -833,7 +833,7 @@ Please cite this report as:
 \setlength\lightrulewidth{0ex}
 \RequirePackage{longtable}
 \RequirePackage{float}
-%\RequirePackage{pdflscape}
+\RequirePackage{pdflscape}
 \RequirePackage{makecell}
 \RequirePackage{xcolor}
 \RequirePackage{colortbl}

--- a/latex/mpi.dtx
+++ b/latex/mpi.dtx
@@ -156,8 +156,23 @@
 %
 %    \begin{macrocode}
 %<*mpi-aebr|mpi-far|mpi-plenary>
+\RequirePackage{amsmath}
 \RequirePackage{mathspec}
 \setallmainfonts{Times New Roman}
+\setsansfont[Mapping=tex-text,
+  ItalicFont = {Arial Italic},
+  BoldFont = {Arial Bold},
+  BoldItalicFont = {Arial Bold Italic}]{Arial}
+\setmathsf[Mapping=tex-text,
+    Numbers=Monospaced,
+    ItalicFont     = {Times New Roman Italic},
+    BoldFont       = {Times New Roman Bold},
+    BoldItalicFont = {Times New Roman Bold Italic}]{Times New Roman}
+\setmathtt[Mapping=tex-text,
+    Numbers=Monospaced,
+    ItalicFont     = {Times New Roman Italic},
+    BoldFont       = {Times New Roman Bold},
+    BoldItalicFont = {Times New Roman Bold Italic}]{Times New Roman}
 %</mpi-aebr|mpi-far|mpi-plenary>
 %    \end{macrocode}
 %

--- a/latex/mpi.dtx
+++ b/latex/mpi.dtx
@@ -158,20 +158,6 @@
 %<*mpi-aebr|mpi-far|mpi-plenary>
 \RequirePackage{mathspec}
 \setallmainfonts{Times New Roman}
-\setsansfont[Mapping=tex-text,
-  ItalicFont = {Arial Italic},
-  BoldFont = {Arial Bold},
-  BoldItalicFont = {Arial Bold Italic}]{Arial}
-\setmathsf[Mapping=tex-text,
-    Numbers=Monospaced,
-    ItalicFont     = {Times New Roman Italic},
-    BoldFont       = {Times New Roman Bold},
-    BoldItalicFont = {Times New Roman Bold Italic}]{Times New Roman}
-\setmathtt[Mapping=tex-text,
-    Numbers=Monospaced,
-    ItalicFont     = {Times New Roman Italic},
-    BoldFont       = {Times New Roman Bold},
-    BoldItalicFont = {Times New Roman Bold Italic}]{Times New Roman}
 %</mpi-aebr|mpi-far|mpi-plenary>
 %    \end{macrocode}
 %

--- a/latex/mpi.dtx
+++ b/latex/mpi.dtx
@@ -798,8 +798,7 @@ Please cite this report as:
 %<*mpi-aebr|mpi-far|mpi-plenary>
 \RequirePackage[usegeometry]{typearea}
 \newenvironment{flandscape}
-    {\savegeometry{defaultgeo}
-     \clearpage
+    {\clearpage
      \KOMAoptions{paper=landscape,DIV=current}%switch to landscape
      \newgeometry{% geometry settings for landscape
        left=0.8125in, right=1in, top=2.5cm, bottom=1.25in, footskip=0.875in
@@ -808,7 +807,7 @@ Please cite this report as:
     }
     {\clearpage
      \KOMAoptions{paper=portrait,DIV=current}%switch to portrait
-     \loadgeometry{defaultgeo}
+     \restoregeometry
      \fancyhfoffset{0pt}% <- recalculate head and foot width for fancyhdr
     }
 %</mpi-aebr|mpi-far|mpi-plenary>

--- a/latex/mpi.dtx
+++ b/latex/mpi.dtx
@@ -807,6 +807,7 @@ Please cite this report as:
     }
     {\clearpage
      \KOMAoptions{paper=portrait,DIV=current}%switch to portrait
+     \restoregeometry
      \pagestyle{plain}
     }
 %</mpi-aebr|mpi-far|mpi-plenary>

--- a/latex/mpi.dtx
+++ b/latex/mpi.dtx
@@ -225,7 +225,7 @@
     \renewcommand{\headrulewidth}{0pt}
   }
 %</mpi-aebr|mpi-far|mpi-plenary>
-%   \end{macrocode}
+%    \end{macrocode}
 %
 % \section{Bibliography}
 %
@@ -252,9 +252,14 @@
 \newcommand{\citet}{\textcite}
 \newcommand{\citep}{\parencite}
 \renewcommand{\cite}{\textcite}
-
+%</mpi-aebr|mpi-far|mpi-plenary>
+%    \end{macrocode}
+%
 % Newer versions of biblatex have better support for different sort keys
 % on citations and bibliography. Until then, override \printbibliography
+%
+%    \begin{macrocode}
+%<*mpi-aebr|mpi-far|mpi-plenary>
 \let\oldprintbibliography\printbibliography
 \renewcommand*\printbibliography{
   \endrefcontext
@@ -262,48 +267,80 @@
     \oldprintbibliography
   \end{refcontext}
 }
-
+%</mpi-aebr|mpi-far|mpi-plenary>
+%    \end{macrocode}
+%
 % Use a comma between multiple citations:
-\renewcommand*{\multicitedelim}{,\addspace}
+%    \begin{macrocode}
+%<mpi-aebr|mpi-far|mpi-plenary>\renewcommand*{\multicitedelim}{,\addspace}
+%    \end{macrocode}
+%
 % Use a semicolon between multiple names in text citations:
+%    \begin{macrocode}
+%<*mpi-aebr|mpi-far|mpi-plenary>
 \renewcommand*{\multinamedelim}{\addcomma\addspace}
 \renewcommand*{\finalnamedelim}{\addspace\&\addspace}
+%</mpi-aebr|mpi-far|mpi-plenary>
+%    \end{macrocode}
+%
 % in bibliography:
+%    \begin{macrocode}
+%<*mpi-aebr|mpi-far|mpi-plenary>
 \DeclareDelimFormat[bib,biblist]{finalnamedelim}{\addsemicolon\addspace}
 \AtBeginBibliography{%
   \renewcommand*{\bibinitdelim}{}%
   \renewcommand*{\revsdnamedelim}{}%
   \renewcommand*{\bibpagespunct}{\addcolon\addspace}%
 }
-
+%</mpi-aebr|mpi-far|mpi-plenary>
+%    \end{macrocode}
+%
 % Have a maximum of two authors in citation commands:
 % Patches https://github.com/plk/biblatex-apa/blob/v6.8/tex/latex/biblatex-apa/cbx/apa.cbx
 % \xpatchnameformat{labelname}{\ifciteseen}{\ifnumcomp{\value{listtotal}}{>}{2}}{}{Patch of labelname failed}
 
 % Redefine the nameyeardelim command, to put a space between the authors and the year in citations
 % in citations, updates https://github.com/plk/biblatex-apa/blob/v6.8/tex/latex/biblatex-apa/cbx/apa.cbx
+%    \begin{macrocode}
+%<*mpi-aebr|mpi-far|mpi-plenary>
 \DeclareDelimFormat[bib]{nameyeardelim}{\space\nopunct}
 \renewcommand*{\nameyeardelim}{\space}
-
+%</mpi-aebr|mpi-far|mpi-plenary>
+%    \end{macrocode}
+%
 % Update the author macro so that there is no period after the authors, for authors without initials, in the bibliography
 % Patches https://github.com/plk/biblatex-apa/blob/v6.8/tex/latex/biblatex-apa/bbx/apa.bbx
 % \xpatchbibmacro{author}{\newunit\newblock}{}{}{Patch of author macro failed}
 
 % Turn extra commas inserted by name:apa:family-given into semicolons
+%    \begin{macrocode}
+%<*mpi-aebr|mpi-far|mpi-plenary>
 \xpatchbibmacro{name:apa:family-given}{\apablx@ifrevnameappcomma{\addcomma}}{\apablx@ifrevnameappcomma{\addsemicolon}}{}{Patch of name:apa:family-given macro failed}
-
+%</mpi-aebr|mpi-far|mpi-plenary>
+%    \end{macrocode}
+%
 % Not sure what this one is doing!
+%    \begin{macrocode}
+%<*mpi-aebr|mpi-far|mpi-plenary>
 \xpatchbibmacro{date+extradate}{%
   \printtext[parens]%
   }{%
     \setunit{\addperiod\space}%
       \printtext%
       }{}{}
-
+%</mpi-aebr|mpi-far|mpi-plenary>
+%    \end{macrocode}
+%
 % Add location+publisher to book
+%    \begin{macrocode}
+%<*mpi-aebr|mpi-far|mpi-plenary>
 \xpatchbibdriver{book}{\printlist{publisher}}{\usebibmacro{location+publisher}}{}{Patch of book driver failed}
-
+%</mpi-aebr|mpi-far|mpi-plenary>
+%    \end{macrocode}
+%
 % Change the order of the publisher and the location, so it is `publisher, location` rather than `location: publisher`, in the bibliography:
+%    \begin{macrocode}
+%<*mpi-aebr|mpi-far|mpi-plenary>
 \xpatchbibmacro{location+publisher}{%
   \printlist{location}%
   \setunit*{\addcomma\space}%
@@ -311,38 +348,52 @@
   \printlist{publisher}%
   \setunit*{\addcomma\space}%
   \printlist{location}}{}{Patch of location+publisher macro failed}
-
+%</mpi-aebr|mpi-far|mpi-plenary>
+%    \end{macrocode}
+%
 % Do not italisise the title of books or collections in the bibliography:
+%    \begin{macrocode}
+%<*mpi-aebr|mpi-far|mpi-plenary>
 \DeclareFieldFormat{booktitle}{#1} %Overriding definition in biblatex.def
 \DeclareFieldFormat{maintitle}{#1} %Overriding definition in biblatex.def
 \DeclareFieldFormat[thesis]{title}{#1}
 \DeclareFieldFormat[unpublished]{title}{#1}
-
-% Italicise the "In:" in collections in the bibliography:
-\xpatchbibmacro{in}{\bibcpstring{in}\setunit{\space}}{\mkbibemph{\bibcpstring{in}}\addcolon\setunit{\space}}{}{Patch of 'in' macro failed}
-
-% No comma after the journal title in the bibliography:
-\xpatchbibmacro{journal+issuetitle}{\addcomma}{}{}{}
-
-% Italicise the number in articles
-\DeclareFieldFormat[article]{number}{\mkbibemph{\mkbibparens{\apanum{#1}}}}
-
-% Space between the volume and the number in articles
-\xpatchbibmacro{journal+issuetitle}{\printfield{number}}{\setunit{\addspace}\printfield{number}}{}{}
-
-% Always finish with a period
-% \renewbibmacro*{apa:finpunct}{\addperiod} % finpunct is gone
-
-
-% Add full stop after title for theses
-\DeclareFieldFormat[thesis]{title}{#1\addperiod}
-
-% Gets rid of parentheses around page number
-\DeclareFieldFormat{addendum}{{#1}}
-
 %</mpi-aebr|mpi-far|mpi-plenary>
 %    \end{macrocode}
 %
+% Italicise the "In:" in collections in the bibliography:
+%    \begin{macrocode}
+%<mpi-aebr|mpi-far|mpi-plenary>\xpatchbibmacro{in}{\bibcpstring{in}\setunit{\space}}{\mkbibemph{\bibcpstring{in}}\addcolon\setunit{\space}}{}{Patch of 'in' macro failed}
+
+
+% No comma after the journal title in the bibliography:
+%    \begin{macrocode}
+%<mpi-aebr|mpi-far|mpi-plenary>\xpatchbibmacro{journal+issuetitle}{\addcomma}{}{}{}
+%    \end{macrocode}
+%
+% Italicise the number in articles
+%    \begin{macrocode}
+%<mpi-aebr|mpi-far|mpi-plenary>\DeclareFieldFormat[article]{number}{\mkbibemph{\mkbibparens{\apanum{#1}}}}
+%    \end{macrocode}
+%
+% Space between the volume and the number in articles
+%    \begin{macrocode}
+%<mpi-aebr|mpi-far|mpi-plenary>\xpatchbibmacro{journal+issuetitle}{\printfield{number}}{\setunit{\addspace}\printfield{number}}{}{}
+%    \end{macrocode}
+%
+% Always finish with a period
+% \renewbibmacro*{apa:finpunct}{\addperiod} % finpunct is gone
+%    \end{macrocode}
+%
+% Add full stop after title for theses
+%    \begin{macrocode}
+%<mpi-aebr|mpi-far|mpi-plenary>\DeclareFieldFormat[thesis]{title}{#1\addperiod}
+%    \end{macrocode}
+%
+% Gets rid of parentheses around page number
+%    \begin{macrocode}
+%<mpi-aebr|mpi-far|mpi-plenary>\DeclareFieldFormat{addendum}{{#1}}
+%    \end{macrocode}
 %
 % \section{Title page}
 %

--- a/latex/mpi.dtx
+++ b/latex/mpi.dtx
@@ -386,7 +386,8 @@
 %    \end{macrocode}
 %
 % Always finish with a period
-% \renewbibmacro*{apa:finpunct}{\addperiod} % finpunct is gone
+%    \begin{macrocode}
+%<mpi-aebr|mpi-far|mpi-plenary>\renewbibmacro*{apa:finpunct}{\addperiod} % finpunct is gone
 %    \end{macrocode}
 %
 % Add full stop after title for theses

--- a/latex/mpi.dtx
+++ b/latex/mpi.dtx
@@ -224,7 +224,6 @@
     \renewcommand{\footrulewidth}{0.3pt}
     \renewcommand{\headrulewidth}{0pt}
   }
-\savegeometry{defaultgeo}  
 %</mpi-aebr|mpi-far|mpi-plenary>
 %    \end{macrocode}
 %
@@ -806,10 +805,9 @@ Please cite this report as:
      }%
      \fancyhfoffset{0pt}% recalculate head and foot width for fancyhdr
     }
-    {\KOMAoptions{paper=portrait,DIV=current}%switch to portrait
-     \loadgeometry{defaultgeo}
-     \fancyhfoffset{0pt}% <- recalculate head and foot width for fancyhdr
-     \clearpage
+    {\clearpage
+     \KOMAoptions{paper=portrait,DIV=current}%switch to portrait
+     \pagestyle{plain}
     }
 %</mpi-aebr|mpi-far|mpi-plenary>
 %    \end{macrocode}

--- a/latex/mpi.dtx
+++ b/latex/mpi.dtx
@@ -825,7 +825,7 @@ Please cite this report as:
 \setlength\lightrulewidth{0ex}
 \RequirePackage{longtable}
 \RequirePackage{float}
-\RequirePackage{pdflscape}
+%\RequirePackage{pdflscape}
 \RequirePackage{makecell}
 \RequirePackage{xcolor}
 \RequirePackage{colortbl}

--- a/latex/mpi.dtx
+++ b/latex/mpi.dtx
@@ -793,6 +793,7 @@ Please cite this report as:
 %
 % Fisheries New Zealand require that footers are rotated on landscape pages.
 % This is achieved by defining a new full landscape environment (flandscape).
+% See https://github.com/dragonfly-science/mpi-latex-templates/issues/26
 %    \begin{macrocode}
 %<*mpi-aebr|mpi-far|mpi-plenary>
 \RequirePackage[usegeometry]{typearea}

--- a/latex/mpi.dtx
+++ b/latex/mpi.dtx
@@ -224,6 +224,7 @@
     \renewcommand{\footrulewidth}{0.3pt}
     \renewcommand{\headrulewidth}{0pt}
   }
+\savegeometry{defaultgeo}  
 %</mpi-aebr|mpi-far|mpi-plenary>
 %    \end{macrocode}
 %
@@ -447,7 +448,7 @@
 %
 %    \begin{macrocode}
 %<*mpi-aebr|mpi-far|mpi-plenary>
-  \renewcommand{\@date}{\the\year}
+\renewcommand{\@date}{\the\year}
 \newcommand{\reportmonth}[1]{\renewcommand{\@month}{#1}}
 \newcommand{\@month}{MMM}
 %</mpi-aebr|mpi-far|mpi-plenary>
@@ -807,7 +808,7 @@ Please cite this report as:
     }
     {\clearpage
      \KOMAoptions{paper=portrait,DIV=current}%switch to portrait
-     \restoregeometry
+     \loadgeometry{defaultgeo}
      \fancyhfoffset{0pt}% <- recalculate head and foot width for fancyhdr
     }
 %</mpi-aebr|mpi-far|mpi-plenary>

--- a/latex/mpi.dtx
+++ b/latex/mpi.dtx
@@ -796,6 +796,7 @@ Please cite this report as:
 % See https://github.com/dragonfly-science/mpi-latex-templates/issues/26
 %    \begin{macrocode}
 %<*mpi-aebr|mpi-far|mpi-plenary>
+\RequirePackage{pdflscape}
 \fancypagestyle{lscapefoot}{%
 \fancyhf{} % clear all header and footer fields
 \fancyfoot[LE]{%
@@ -833,7 +834,6 @@ Please cite this report as:
 \setlength\lightrulewidth{0ex}
 \RequirePackage{longtable}
 \RequirePackage{float}
-%\RequirePackage{pdflscape}
 \RequirePackage{makecell}
 \RequirePackage{xcolor}
 \RequirePackage{colortbl}

--- a/latex/mpi.dtx
+++ b/latex/mpi.dtx
@@ -789,6 +789,31 @@ Please cite this report as:
 %</common>
 %    \end{macrocode}
 %
+% \section{Full landscape pages}
+%
+% Fisheries New Zealand require that footers are rotated on landscape pages.
+% This is achieved by defining a new full landscape environment (flandscape).
+%    \begin{macrocode}
+%<*mpi-aebr|mpi-far|mpi-plenary>
+\RequirePackage[usegeometry]{typearea}
+\savegeometry{defaultgeo}
+\newenvironment{flandscape}
+    {\clearpage
+     \KOMAoptions{paper=landscape,DIV=current}%switch to landscape
+     \newgeometry{% geometry settings for landscape
+       left=0.8125in, right=1in, top=2.5cm, bottom=1.25in, footskip=0.875in
+     }%
+     \fancyhfoffset{0pt}% recalculate head and foot width for fancyhdr
+    }
+    {\clearpage
+     \KOMAoptions{paper=portrait,DIV=current}%switch to portrait
+     \loadgeometry{defaultgeo}
+     \fancyhfoffset{0pt}% <- recalculate head and foot width for fancyhdr
+    }
+%</mpi-aebr|mpi-far|mpi-plenary>
+%    \end{macrocode}
+%
+%
 %  \section{Additional Packages}
 % We also various table-related packages, guided by the kableExtra requirements, 
 % and set up the booktabs rules so kable tables conform to FNZ requirements.

--- a/latex/mpi.dtx
+++ b/latex/mpi.dtx
@@ -68,17 +68,17 @@
 %
 % \GetFileInfo{mpi.dtx}
 %
-% \title{Formatting Ministry for Primary Industries reports}
+% \title{Formatting Fisheries New Zealand reports}
 % \author{Dragonfly Science}
 % \maketitle
 %
 % \begin{abstract}
-%  This is a set of classes that are used to format \LaTeX{} documents according the
-%  Ministry for Primary Industries formatting requirements. There are three document
+%  This is a set of classes that are used to format \LaTeX{} documents according to the
+%  Fisheries New Zealand formatting requirements. There are three document
 %  classes provided: ``mpi-aebr'', for formatting Aquatic Environment and Biodiversity
 %  Reports, ``mpi-far'', for formatting Fisheries Assessment Reports and ``mpi-plenary``
-%  for MPI Plenary Documents. Using these packages allows for producing publication
-%  ready documents.
+%  for stock assessment Plenary Documents. Using these packages allows the production of 
+%  publication ready documents.
 % \end{abstract}
 % \clearpage
 % \tableofcontents

--- a/latex/mpi.dtx
+++ b/latex/mpi.dtx
@@ -157,20 +157,6 @@
 %<*mpi-aebr|mpi-far|mpi-plenary>
 \RequirePackage[math]{mathspec}
 \setallmainfonts{Times New Roman}
-\setsansfont[Mapping=tex-text,
-  ItalicFont = {Arial Italic},
-  BoldFont = {Arial Bold},
-  BoldItalicFont = {Arial Bold Italic}]{Arial}
-\setmathsf[Mapping=tex-text,
-    Numbers=Monospaced,
-    ItalicFont     = {Times New Roman Italic},
-    BoldFont       = {Times New Roman Bold},
-    BoldItalicFont = {Times New Roman Bold Italic}]{Times New Roman}
-\setmathtt[Mapping=tex-text,
-    Numbers=Monospaced,
-    ItalicFont     = {Times New Roman Italic},
-    BoldFont       = {Times New Roman Bold},
-    BoldItalicFont = {Times New Roman Bold Italic}]{Times New Roman}
 %</mpi-aebr|mpi-far|mpi-plenary>
 %    \end{macrocode}
 %

--- a/latex/mpi.dtx
+++ b/latex/mpi.dtx
@@ -796,20 +796,27 @@ Please cite this report as:
 % See https://github.com/dragonfly-science/mpi-latex-templates/issues/26
 %    \begin{macrocode}
 %<*mpi-aebr|mpi-far|mpi-plenary>
-\RequirePackage[usegeometry]{typearea}
+\fancypagestyle{lscapefoot}{%
+\fancyhf{} % clear all header and footer fields
+\fancyfoot[LE]{%
+\begin{textblock*}{1.0\textheight}[0,1](190mm,271mm){\rotatebox{90}{\rule{247mm}{0.4pt}}}\end{textblock*}
+\begin{textblock*}{0.7\textwidth}[0,1](192mm,271mm){\rotatebox{90}{\sffamily\scriptsize\thepage\ {\normalsize$\bullet$}\ \footertitle}}\end{textblock*}
+\begin{textblock*}{0.3\textwidth}(192mm,24mm){\rotatebox{90}{\sffamily\scriptsize Fisheries New Zealand}}\end{textblock*}}
+\fancyfoot[LO]{%
+\begin{textblock*}{1.0\textheight}[0,1](190mm,271mm){\rotatebox{90}{\rule{247mm}{0.4pt}}}\end{textblock*}
+\begin{textblock*}{0.3\textwidth}[0,1](192mm,271mm){\rotatebox{90}{\sffamily\scriptsize Fisheries New Zealand}}\end{textblock*}
+\begin{textblock*}{0.7\textwidth}(192mm,24mm){\rotatebox{90}{\sffamily\scriptsize\footertitle\ {\normalsize$\bullet$}\ \thepage}}\end{textblock*}}
+\renewcommand{\headrulewidth}{0pt}
+\renewcommand{\footrulewidth}{0pt}}
 \newenvironment{flandscape}
-    {\clearpage
-     \KOMAoptions{paper=landscape,DIV=current}%switch to landscape
-     \newgeometry{% geometry settings for landscape
-       left=0.8125in, right=1in, top=2.5cm, bottom=1.25in, footskip=0.875in
-     }%
-     \fancyhfoffset{0pt}% recalculate head and foot width for fancyhdr
+    {\newgeometry{hmargin=2.5cm,vmargin=2.5cm}
+     \thispagestyle{lscapefoot}
+     \pagestyle{lscapefoot}
+     \begin{landscape}
     }
-    {\clearpage
-     \KOMAoptions{paper=portrait,DIV=current}%switch to portrait
+    {\end{landscape}
      \restoregeometry
      \pagestyle{plain}
-     \fancyhfoffset{0pt}\\
     }
 %</mpi-aebr|mpi-far|mpi-plenary>
 %    \end{macrocode}

--- a/latex/mpi.dtx
+++ b/latex/mpi.dtx
@@ -256,7 +256,7 @@
 %    \end{macrocode}
 %
 % Newer versions of biblatex have better support for different sort keys
-% on citations and bibliography. Until then, override \printbibliography
+% on citations and bibliography. Until then, override \\printbibliography
 %
 %    \begin{macrocode}
 %<*mpi-aebr|mpi-far|mpi-plenary>
@@ -295,10 +295,14 @@
 %</mpi-aebr|mpi-far|mpi-plenary>
 %    \end{macrocode}
 %
-% Have a maximum of two authors in citation commands:
+% [DISABLED] Have a maximum of two authors in citation commands:
+%    \begin{macrocode}
+%<*mpi-aebr|mpi-far|mpi-plenary>
 % Patches https://github.com/plk/biblatex-apa/blob/v6.8/tex/latex/biblatex-apa/cbx/apa.cbx
 % \xpatchnameformat{labelname}{\ifciteseen}{\ifnumcomp{\value{listtotal}}{>}{2}}{}{Patch of labelname failed}
-
+%</mpi-aebr|mpi-far|mpi-plenary>
+%    \end{macrocode}
+%
 % Redefine the nameyeardelim command, to put a space between the authors and the year in citations
 % in citations, updates https://github.com/plk/biblatex-apa/blob/v6.8/tex/latex/biblatex-apa/cbx/apa.cbx
 %    \begin{macrocode}
@@ -308,15 +312,17 @@
 %</mpi-aebr|mpi-far|mpi-plenary>
 %    \end{macrocode}
 %
-% Update the author macro so that there is no period after the authors, for authors without initials, in the bibliography
+% [DISABLED] Update the author macro so that there is no period after the authors, for authors without initials, in the bibliography
 % Patches https://github.com/plk/biblatex-apa/blob/v6.8/tex/latex/biblatex-apa/bbx/apa.bbx
-% \xpatchbibmacro{author}{\newunit\newblock}{}{}{Patch of author macro failed}
-
-% Turn extra commas inserted by name:apa:family-given into semicolons
 %    \begin{macrocode}
 %<*mpi-aebr|mpi-far|mpi-plenary>
-\xpatchbibmacro{name:apa:family-given}{\apablx@ifrevnameappcomma{\addcomma}}{\apablx@ifrevnameappcomma{\addsemicolon}}{}{Patch of name:apa:family-given macro failed}
+% \xpatchbibmacro{author}{\newunit\newblock}{}{}{Patch of author macro failed}
 %</mpi-aebr|mpi-far|mpi-plenary>
+%    \end{macrocode}
+%
+% Turn extra commas inserted by name:apa:family-given into semicolons
+%    \begin{macrocode}
+%<mpi-aebr|mpi-far|mpi-plenary>\xpatchbibmacro{name:apa:family-given}{\apablx@ifrevnameappcomma{\addcomma}}{\apablx@ifrevnameappcomma{\addsemicolon}}{}{Patch of name:apa:family-given macro failed}
 %    \end{macrocode}
 %
 % Not sure what this one is doing!
@@ -333,9 +339,7 @@
 %
 % Add location+publisher to book
 %    \begin{macrocode}
-%<*mpi-aebr|mpi-far|mpi-plenary>
-\xpatchbibdriver{book}{\printlist{publisher}}{\usebibmacro{location+publisher}}{}{Patch of book driver failed}
-%</mpi-aebr|mpi-far|mpi-plenary>
+%<mpi-aebr|mpi-far|mpi-plenary>\xpatchbibdriver{book}{\printlist{publisher}}{\usebibmacro{location+publisher}}{}{Patch of book driver failed}
 %    \end{macrocode}
 %
 % Change the order of the publisher and the location, so it is `publisher, location` rather than `location: publisher`, in the bibliography:
@@ -364,8 +368,8 @@
 % Italicise the "In:" in collections in the bibliography:
 %    \begin{macrocode}
 %<mpi-aebr|mpi-far|mpi-plenary>\xpatchbibmacro{in}{\bibcpstring{in}\setunit{\space}}{\mkbibemph{\bibcpstring{in}}\addcolon\setunit{\space}}{}{Patch of 'in' macro failed}
-
-
+%    \end{macrocode}
+%
 % No comma after the journal title in the bibliography:
 %    \begin{macrocode}
 %<mpi-aebr|mpi-far|mpi-plenary>\xpatchbibmacro{journal+issuetitle}{\addcomma}{}{}{}

--- a/latex/mpi.dtx
+++ b/latex/mpi.dtx
@@ -809,7 +809,7 @@ Please cite this report as:
      \KOMAoptions{paper=portrait,DIV=current}%switch to portrait
      \restoregeometry
      \pagestyle{plain}
-     \fancyhfoffset{0pt}
+     \fancyhfoffset{0pt}\\
     }
 %</mpi-aebr|mpi-far|mpi-plenary>
 %    \end{macrocode}

--- a/latex/mpi.dtx
+++ b/latex/mpi.dtx
@@ -797,9 +797,9 @@ Please cite this report as:
 %    \begin{macrocode}
 %<*mpi-aebr|mpi-far|mpi-plenary>
 \RequirePackage[usegeometry]{typearea}
-\savegeometry{defaultgeo}
 \newenvironment{flandscape}
-    {\clearpage
+    {\savegeometry{defaultgeo}
+     \clearpage
      \KOMAoptions{paper=landscape,DIV=current}%switch to landscape
      \newgeometry{% geometry settings for landscape
        left=0.8125in, right=1in, top=2.5cm, bottom=1.25in, footskip=0.875in

--- a/makefile
+++ b/makefile
@@ -24,7 +24,7 @@ latex/mpi.pdf: latex/mpi.dtx latex/mpi.ins latex/affiliation.dbx clean_latex
 	$(RUN) bash -c "cd latex && xelatex mpi.dtx"
 
 .PRECIOUS: package/.build
-package/.build: examples/mpi-far.pdf examples/mpi-plenary.pdf examples/mpi-far-draft.pdf examples/mpi-aebr.pdf
+package/.build: examples/mpi-far.pdf examples/mpi-plenary.pdf examples/mpi-far-draft.pdf examples/mpi-aebr.pdf examples/mpi-tables.pdf
 	$(RUN) bash -c "cd package && debuild -us -uc && mv ../mpi-latex*{.dsc,.changes,.build,tar.xz} . && touch .build"
 
 .PHONY: clean

--- a/makefile
+++ b/makefile
@@ -13,6 +13,7 @@ RUN ?= docker run -it --rm --net=host --user=$$(id -u):$$(id -g) -e RUN= -e TEXI
 #
 all: package/.build
 
+.SECONDARY: 
 examples/%.tex: examples/%.rnw
 	cd examples && Rscript --vanilla -e "library(knitr);opts_chunk\$$set(warning=F, message = FALSE,echo=F,results='asis',fig.lp='fig:',fig.path='images/'); knit('$(<F)',output='$(@F)')"
 

--- a/makefile
+++ b/makefile
@@ -16,7 +16,7 @@ all: package/.build
 examples/%.tex: examples/%.rnw
 	cd examples && Rscript --vanilla -e "library(knitr);opts_chunk\$$set(warning=F, message = FALSE,echo=F,results='asis',fig.lp='fig:',fig.path='images/'); knit('$(<F)',output='$(@F)')"
 
-examples/%.pdf: examples/%.tex examples/test.bib latex/mpi.pdf graphics/FAR.jpg latex/affiliation.dbx clean_examples
+examples/%.pdf: examples/%.tex examples/mpi-tables.tex examples/test.bib latex/mpi.pdf graphics/FAR.jpg latex/affiliation.dbx clean_examples
 	$(RUN) bash -c "cd examples && xelatex $(*) && biber $(*) && xelatex $(*) && xelatex $(*)"
 
 latex/mpi.pdf: latex/mpi.dtx latex/mpi.ins latex/affiliation.dbx clean_latex

--- a/package/debian/changelog
+++ b/package/debian/changelog
@@ -1,6 +1,7 @@
 mpi-latex-templates (1.54) jammy; urgency=medium
 
   * Use mathspec to set maths in Times New Roman
+  * Tidy the bibliography section (code/text sepatation)
 
  -- David Middleton <david@pisces.nz>  Sun, 22 Jan 2023 10:26:43 +1300
 

--- a/package/debian/changelog
+++ b/package/debian/changelog
@@ -2,6 +2,7 @@ mpi-latex-templates (1.54) jammy; urgency=medium
 
   * Use mathspec to set maths in Times New Roman
   * Tidy the bibliography section (code/text sepatation)
+  * Add commonly used packages and set booktab rules so kable tables conform to FNZ requirements
 
  -- David Middleton <david@pisces.nz>  Sun, 22 Jan 2023 10:26:43 +1300
 

--- a/package/debian/changelog
+++ b/package/debian/changelog
@@ -1,8 +1,8 @@
 mpi-latex-templates (1.54) jammy; urgency=medium
 
   * Use mathspec to set maths in Times New Roman
-  * Tidy the bibliography section (code/text sepatation)
-  * Add commonly used packages and set booktab rules so kable tables conform to FNZ requirements
+  * Tidy the bibliography section of mpi.dtx (code/text separation)
+  * Add commonly used packages and set booktab rules so kable tables conform to FNZ requirements (with knitr examples)
   * Add the flandscape environment for full-landscape pages with rotated footer
 
  -- David Middleton <david@pisces.nz>  Wed, 25 Jan 2023 10:32:43 +1300

--- a/package/debian/changelog
+++ b/package/debian/changelog
@@ -1,3 +1,9 @@
+mpi-latex-templates (1.54) jammy; urgency=medium
+
+  * Use mathspec to set maths in Times New Roman
+
+ -- David Middleton <david@pisces.nz>  Sun, 22 Jan 2023 10:26:43 +1300
+
 mpi-latex-templates (1.53) jammy; urgency=medium
 
   * Add the No. prefix for AEBRs

--- a/package/debian/changelog
+++ b/package/debian/changelog
@@ -3,8 +3,9 @@ mpi-latex-templates (1.54) jammy; urgency=medium
   * Use mathspec to set maths in Times New Roman
   * Tidy the bibliography section (code/text sepatation)
   * Add commonly used packages and set booktab rules so kable tables conform to FNZ requirements
+  * Add the flandscape environment for full-landscape pages with rotated footer
 
- -- David Middleton <david@pisces.nz>  Sun, 22 Jan 2023 10:26:43 +1300
+ -- David Middleton <david@pisces.nz>  Wed, 25 Jan 2023 10:32:43 +1300
 
 mpi-latex-templates (1.53) jammy; urgency=medium
 

--- a/package/debian/changelog
+++ b/package/debian/changelog
@@ -1,3 +1,9 @@
+mpi-latex-templates (1.55) jammy; urgency=medium
+
+  * Don't use typearea to implement the flandscape environment
+
+ -- David Middleton <david@pisces.nz>  Wed, 25 Jan 2023 13:47:18 +1300
+
 mpi-latex-templates (1.54) jammy; urgency=medium
 
   * Use mathspec to set maths in Times New Roman


### PR DESCRIPTION
Addresses #44 by updating the main templates and examples to include various developed in a range of issues, but otherwise having to be implemented in each document.

- Use mathspec to set maths in Times New Roman #4 
- Tidy the bibliography section of mpi.dtx (code/text separation)
- Add commonly used packages and set booktab rules so kable tables conform to FNZ requirements (with knitr examples) #28
- Add the flandscape environment for full-landscape pages with rotated footer #26
